### PR TITLE
Issue 42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pot
 *.pyc
 *.db
+.tox/*
 local_settings.py
 build
 dist

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A URL mapper for the django web framework.
 [![Coverage Status](https://coveralls.io/repos/ConsumerAffairs/django-urlographer/badge.png)](https://coveralls.io/r/ConsumerAffairs/django-urlographer)
 
 
-Features:
+Features
+--
 
 * supplements the django url resolution
 * database + cache driven
@@ -19,3 +20,34 @@ Features:
     * ascii
     * eliminate relative paths
     * extra slashes
+
+
+To run tests locally
+--
+
+```
+tox
+```
+
+To run tests for a specific environment:
+```
+tox -e django16
+```
+
+
+To debug tests locally
+--
+
+* Add `ipdb` to `deps` in `[base]`, example:
+
+```[base]
+deps =
+    mox
+    nose
+    ipdb
+```
+
+Run this command:
+```
+tox -e django16 -- -s
+```

--- a/README.md
+++ b/README.md
@@ -51,3 +51,11 @@ Run this command:
 ```
 tox -e django16 -- -s
 ```
+
+
+To install in current virtualenv
+--
+Make sure your virtualenv is loaded and:
+```
+python setup.py install
+```

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-urlographer',
-    version='0.10.0',
+    version='0.10.1',
     author='Josh Mize',
     author_email='jmize@consumeraffairs.com',
     description='URL mapper for django',

--- a/tox.ini
+++ b/tox.ini
@@ -48,5 +48,4 @@ commands =
 deps =
     coverage
     coveralls
-    django-extensions<=.1.5.9
     {[testenv:django16]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = django16, django17, django18, django19
 deps =
     mox
     nose
-    django-extensions
 
 [testenv]
 commands = django-admin.py test
@@ -17,24 +16,28 @@ setenv =
 deps =
     django>=1.6, <1.7
     django-nose<=1.4.2
+    django-extensions<=1.5.9
     {[base]deps}
 
 [testenv:django17]
 deps =
     django>=1.7, <1.8
     django-nose>=1.4.2
+    django-extensions<=1.5.9
     {[base]deps}
 
 [testenv:django18]
 deps =
     django>=1.8, <1.9
     django-nose>=1.4.2
+    django-extensions<=1.5.9
     {[base]deps}
 
 [testenv:django19]
 deps =
     django>=1.9, <1.10
     django-nose>=1.4.2
+    django-extensions>=1.7.2
     {[base]deps}
 
 [testenv:coverage]
@@ -45,4 +48,5 @@ commands =
 deps =
     coverage
     coveralls
+    django-extensions<=.1.5.9
     {[testenv:django16]deps}

--- a/urlographer/admin.py
+++ b/urlographer/admin.py
@@ -2,6 +2,8 @@
 from django import forms
 from django.contrib import admin
 from django.contrib.sites.models import Site
+from django.db.models.expressions import RawSQL
+
 from urlographer.models import URLMap, ContentMap
 
 
@@ -47,11 +49,10 @@ class URLMapAdminForm(forms.ModelForm):
 class URLMapAdmin(admin.ModelAdmin):
     form = URLMapAdminForm
 
-    def queryset(self, request):
-        # Rename to `get_queryset` in Django version > 1.5
-        return super(URLMapAdmin, self).queryset(request).extra(select={
-            'redirects_count': SQL_COUNT_REDIRECTS
-        })
+    def get_queryset(self, request):
+        return super(URLMapAdmin, self).get_queryset(
+            request
+        ).annotate(redirects_count=RawSQL(SQL_COUNT_REDIRECTS, ()))
 
     def redirects_count(self, obj):
         return obj.redirects_count

--- a/urlographer/admin.py
+++ b/urlographer/admin.py
@@ -25,9 +25,10 @@ class HasRedirectsToItListFilter(admin.SimpleListFilter):
 
     def queryset(self, request, queryset):
         join_sql = SQL_COUNT_REDIRECTS
-        if self.value() == 'yes':
+        value = self.value()
+        if value == 'yes':
             return queryset.extra(where=["(%s)>0" % join_sql])
-        if self.value() == 'no':
+        if value == 'no':
             return queryset.extra(where=["(%s)=0" % join_sql])
 
 


### PR DESCRIPTION
This PR
--
* Applies the fixes described in #42 

Practical test
--
* Go to the main project at URL `/admin/urlographer/urlmap/`

- [ ] On master you should get an `HTTP 500` as in Sentry error: http://sentry.consumeraffairs.com/consumeraffairs/qa/issues/2049/


The same URL should work when you do the below:
* go to your current Django 1.9 virtualenv and run:

```
pip uninstall django-urlographer
```

* go to the django-urlographer repo and run:
```
pip install -e .
```

- [ ] Does the admin URL work?

That's it, thanks!