### PR TITLE
adds celery task to fix redirect loops.

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,7 @@
 fabric
 mox>=0.5.3
 django-test-utilities>=0.5
+model-mommy==1.2.6
 nose
 django-nose
 south

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-urlographer',
-    version='0.10.1',
+    version='0.10.2',
     author='Josh Mize',
     author_email='jmize@consumeraffairs.com',
     description='URL mapper for django',

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = django16, django17, django18, django19
 
 [base]
 deps =
+    model_mommy
     mox
     nose
 

--- a/urlographer/tasks.py
+++ b/urlographer/tasks.py
@@ -38,7 +38,7 @@ class FixRedirectLoopsTask(Task):
     def get_urlmaps_2_hops(self):
         qs_filters = {
             'redirect__status_code__range': (300, 399),
-            'redirect__redirect__status_code': 200}
+            'redirect__redirect__status_code__in': (200, 410)}
         return URLMap.objects.filter(**qs_filters)
 
     def run(self):

--- a/urlographer/tasks.py
+++ b/urlographer/tasks.py
@@ -1,6 +1,11 @@
+
 from celery.decorators import task
+from celery.task import Task
+
+from django.db import transaction
 from django.test.client import RequestFactory
 
+from urlographer.models import URLMap
 from urlographer.views import sitemap
 
 
@@ -9,3 +14,35 @@ def update_sitemap_cache():
     factory = RequestFactory()
     request = factory.get('/sitemap.xml')
     sitemap(request, invalidate_cache=True)
+
+
+class FixRedirectLoopsTask(Task):
+    """
+    Task to automatically fix redirect loops.
+
+    Example scenario:
+
+    Before:
+    A
+    B
+    C -> A
+    D -> C -> A
+
+    After:
+    A
+    B
+    C -> A
+    D -> A
+    """
+
+    def get_urlmaps_2_hops(self):
+        qs_filters = {
+            'redirect__status_code__range': (300, 399),
+            'redirect__redirect__status_code': 200}
+        return URLMap.objects.filter(**qs_filters)
+
+    def run(self):
+        for urlmap in self.get_urlmaps_2_hops():
+            with transaction.atomic():
+                urlmap.redirect = urlmap.redirect.redirect
+                urlmap.save()

--- a/urlographer/tasks.py
+++ b/urlographer/tasks.py
@@ -1,5 +1,4 @@
 
-from celery.decorators import task
 from celery.task import Task
 
 from django.db import transaction
@@ -9,11 +8,12 @@ from urlographer.models import URLMap
 from urlographer.views import sitemap
 
 
-@task(ignore_result=True)
-def update_sitemap_cache():
-    factory = RequestFactory()
-    request = factory.get('/sitemap.xml')
-    sitemap(request, invalidate_cache=True)
+class UpdateSitemapCacheTask(Task):
+
+    def run(self):
+        factory = RequestFactory()
+        request = factory.get('/sitemap.xml')
+        sitemap(request, invalidate_cache=True)
 
 
 class FixRedirectLoopsTask(Task):

--- a/urlographer/tests.py
+++ b/urlographer/tests.py
@@ -825,7 +825,7 @@ class SitemapTest(TestCase):
             response.content, self.mock_contrib_sitemap_response.content)
 
 
-class UpdateSitemapCacheTest(TestCase):
+class UpdateSitemapCacheTaskTest(TestCase):
     def setUp(self):
         self.mock = mox.Mox()
 
@@ -836,7 +836,7 @@ class UpdateSitemapCacheTest(TestCase):
         self.mock.StubOutWithMock(tasks, 'sitemap')
         tasks.sitemap(mox.IsA(HttpRequest), invalidate_cache=True)
         self.mock.ReplayAll()
-        tasks.update_sitemap_cache()
+        tasks.UpdateSitemapCacheTask().run()
         self.mock.VerifyAll()
 
 


### PR DESCRIPTION
Adds `FixRedirectLoopsTask` task to fix redirect loops

### Test Instructions

* the below query will be reused before and after the management command is run. It shows the redirect loops with one "extra" hop:

```
SELECT map1.path AS "initial_path", map3.path AS "final_path", map3.status_code AS "status_code"
FROM consumeraffairs.urlographer_urlmap AS map1, consumeraffairs.urlographer_urlmap AS map2, consumeraffairs.urlographer_urlmap AS map3
WHERE map1.redirect_id = map2.id
AND map2.redirect_id = map3.id
AND NOT (map3.status_code BETWEEN 300 AND 399)
ORDER BY map1.path, map3.path
```

* run query:

- [x] you should have around 137 rows (*around* because this may vary depending on what DB version you have restored locally -- exact number does not really matter)

* fetch this repo locally and navigate into it
* checkout into this branch
* run the newly added task via `./manage shell_plus`:

```
from urlographer.tasks import FixRedirectLoopsTask
FixRedirectLoopsTask()()
```
 
* After it completes, run query again:

- [x] You should have 0 rows returned now

That's it, thanks!