### PR TITLE
Track changes made by FixRedirectLoopsTask.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-urlographer',
-    version='0.10.2',
+    version='0.10.3',
     author='Josh Mize',
     author_email='jmize@consumeraffairs.com',
     description='URL mapper for django',

--- a/urlographer/tasks.py
+++ b/urlographer/tasks.py
@@ -61,6 +61,7 @@ class FixRedirectLoopsTask(Task):
             content_type_id = ContentType.objects.get_for_model(urlmap).pk
             with transaction.atomic():
                 urlmap.redirect = urlmap.redirect.redirect
+                urlmap.on_sitemap = False
                 urlmap.save()
                 change_message = (
                     'Updated to redirect directly to "{0}" by '

--- a/urlographer/tasks.py
+++ b/urlographer/tasks.py
@@ -1,6 +1,12 @@
 
 from celery.task import Task
 
+from django.contrib.admin.models import (
+    CHANGE,
+    LogEntry
+)
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.test.client import RequestFactory
 
@@ -35,6 +41,15 @@ class FixRedirectLoopsTask(Task):
     D -> A
     """
 
+    user_username = 'fix_redirect_loops_task'
+
+    def get_or_create_task_user(self):
+        try:
+            return User.objects.get(username=self.user_username)
+        except User.DoesNotExist:
+            return User.objects.create_user(
+                self.user_username, 'dev@consumeraffairs.com')
+
     def get_urlmaps_2_hops(self):
         qs_filters = {
             'redirect__status_code__range': (300, 399),
@@ -43,6 +58,19 @@ class FixRedirectLoopsTask(Task):
 
     def run(self):
         for urlmap in self.get_urlmaps_2_hops():
+            content_type_id = ContentType.objects.get_for_model(urlmap).pk
             with transaction.atomic():
                 urlmap.redirect = urlmap.redirect.redirect
                 urlmap.save()
+                change_message = (
+                    'Updated to redirect directly to "{0}" by '
+                    'FixRedirectLoopsTask'.format(urlmap.redirect.path)
+                )
+                LogEntry.objects.log_action(
+                    user_id=self.get_or_create_task_user().id,
+                    content_type_id=content_type_id,
+                    object_id=urlmap.id,
+                    object_repr=str(urlmap),
+                    action_flag=CHANGE,
+                    change_message=change_message
+                )

--- a/urlographer/tests.py
+++ b/urlographer/tests.py
@@ -930,8 +930,10 @@ class FixRedirectLoopsTaskTest(TestCase):
 
         updated_url_d = models.URLMap.objects.get(pk=self.urlD.pk)
         self.assertEqual(updated_url_d.redirect, self.urlA)
+        self.assertFalse(updated_url_d.on_sitemap)
         updated_url_g = models.URLMap.objects.get(pk=self.urlG.pk)
         self.assertEqual(updated_url_g.redirect, self.urlB)
+        self.assertFalse(updated_url_g.on_sitemap)
 
         # assert LogEntry entries have been created correctly
         content_type_id = ContentType.objects.get_for_model(self.urlD).pk


### PR DESCRIPTION
## Track changes made to URLs by `FixRedirectLoopsTask`

### Test Instructions
- the below query will be reused before and after the management command is run. It shows the redirect loops with one "extra" hop:

```
SELECT map1.path AS "initial_path", map3.path AS "final_path", map3.status_code AS "status_code"
FROM consumeraffairs.urlographer_urlmap AS map1, consumeraffairs.urlographer_urlmap AS map2, consumeraffairs.urlographer_urlmap AS map3
WHERE map1.redirect_id = map2.id
AND map2.redirect_id = map3.id
AND NOT (map3.status_code BETWEEN 300 AND 399)
ORDER BY map1.path, map3.path
```

- run query:
- [x] you should have around 216 rows (_around_ because this may vary depending on what DB version you have restored locally -- exact number does not really matter)

- [x] pick one of the URLs that should be updated by `FixRedirectLoopsTask`
  * e.g. `/cell_phones/ameritech.htm` and keep not of its URL in the admin, in the case of `/cell_phones/ameritech.htm` that would be `/admin/urlographer/urlmap/12397/change/`

- [x] the "History" for this URLMap should be blank; keep the tab with this history open

Let's run the task. Make sure the latest `urlographer` (as submitted in this PR) is installed in your virtual environment.
- if not, fetch this repo locally and navigate into it, checkout into this branch, and `python setup.py develop` in your virtualenv
- run the newly added task via `./manage.py shell_plus`:

```
from urlographer.tasks import FixRedirectLoopsTask
FixRedirectLoopsTask()()
```

- After it completes, run query again:
- [x] You should have 0 rows returned now

- Navigate again to the URLMap admin URL above
- [x] the URLMap's history should show a message that the URL was updated by `FixRedirectLoopsTask`, as in the screenshot below:

<img width="999" alt="screen shot 2016-11-08 at 5 31 30 pm" src="https://cloud.githubusercontent.com/assets/1561096/20107574/430a54f6-a5d9-11e6-8943-2f28dc557200.png">

That's it, thanks!
