### PR TITLE
URLMap model cleanup, append slash when not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 env:
-    - TOXENV=django16
     - TOXENV=django17
     - TOXENV=django18
     - TOXENV=django19

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ tox
 
 To run tests for a specific environment:
 ```
-tox -e django16
+tox -e django19
 ```
 
 
@@ -49,7 +49,14 @@ deps =
 
 Run this command:
 ```
-tox -e django16 -- -s
+tox -e django19 -- -s
+```
+
+To run coverage locally
+--
+
+```
+coverage report -m
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='django-urlographer',
-    version='0.10.3',
+    version='0.10.4',
     author='Josh Mize',
     author_email='jmize@consumeraffairs.com',
     description='URL mapper for django',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django16, django17, django18, django19
+envlist = django17, django18, django19
 
 [base]
 deps =
@@ -12,13 +12,6 @@ commands = django-admin.py test
 setenv =
     DJANGO_SETTINGS_MODULE=test_app.settings
     PYTHONPATH={toxinidir}
-
-[testenv:django16]
-deps =
-    django>=1.6, <1.7
-    django-nose<=1.4.2
-    django-extensions<=1.5.9
-    {[base]deps}
 
 [testenv:django17]
 deps =
@@ -49,4 +42,4 @@ commands =
 deps =
     coverage
     coveralls
-    {[testenv:django16]deps}
+    {[testenv:django17]deps}

--- a/urlographer/models.py
+++ b/urlographer/models.py
@@ -154,7 +154,8 @@ class URLMap(TimeStampedModel):
         Must be called after the *hexdigest* has been set or an
         AssertionError will be raised
         """
-        assert self.hexdigest
+        if not self.hexdigest:
+            raise ValueError('URLMap has unset hexdigest')
         return settings.URLOGRAPHER_CACHE_PREFIX + self.hexdigest
 
     def set_hexdigest(self):

--- a/urlographer/models.py
+++ b/urlographer/models.py
@@ -30,8 +30,6 @@ settings.URLOGRAPHER_CACHE_TIMEOUT = getattr(
     settings, 'URLOGRAPHER_CACHE_TIMEOUT', 0)
 settings.URLOGRAPHER_CACHE_PREFIX = getattr(
     settings, 'URLOGRAPHER_CACHE_PREFIX', 'urlographer:')
-settings.URLOGRAPHER_INDEX_ALIAS = getattr(
-    settings, 'URLOGRAPHER_INDEX_ALIAS', 'index.html')  # do NOT include /
 
 
 class ContentMap(TimeStampedModel):
@@ -93,16 +91,7 @@ class URLMapManager(models.Manager):
             if cached:
                 return cached
 
-        if path.endswith('/') and settings.URLOGRAPHER_INDEX_ALIAS:
-            try:
-                url = self.get(hexdigest=url.hexdigest)
-            except self.model.DoesNotExist:
-                url = self.cached_get(
-                    site, path + settings.URLOGRAPHER_INDEX_ALIAS,
-                    force_cache_invalidation=force_cache_invalidation)
-        else:
-            url = self.get(hexdigest=url.hexdigest)
-
+        url = self.get(hexdigest=url.hexdigest)
         # accessing foreignkeys caches instances with the object
         url.site
         url.content_map
@@ -224,9 +213,5 @@ class URLMap(TimeStampedModel):
         self.site
         self.content_map
         self.redirect
-        cache.set(self.cache_key(), self,
-                  timeout=settings.URLOGRAPHER_CACHE_TIMEOUT)
-        if self.path.endswith('/' + settings.URLOGRAPHER_INDEX_ALIAS):
-            self._default_manager.cached_get(
-                self.site, self.path[:-len(settings.URLOGRAPHER_INDEX_ALIAS)],
-                force_cache_invalidation=True)
+        cache.set(
+            self.cache_key(), self, timeout=settings.URLOGRAPHER_CACHE_TIMEOUT)

--- a/urlographer/tests.py
+++ b/urlographer/tests.py
@@ -130,6 +130,16 @@ class URLMapTest(TestCase):
         self.assertEqual(
             self.url.hexdigest, self.hexdigest)
 
+    def test_cache_key(self):
+        self.url.hexdigest = 'a6dd1406d4e5aadaafed9c2d285d36bd'
+        self.assertEqual(self.url.cache_key(), self.cache_key)
+
+    def test_cache_key_with_hexdigest_unset(self):
+        with self.assertRaises(ValueError) as context:
+            self.url.cache_key()
+        self.assertEqual(
+            context.exception.message, 'URLMap has unset hexdigest')
+
     def test_save(self):
         self.site.save()
         self.url.site = self.site

--- a/urlographer/tests.py
+++ b/urlographer/tests.py
@@ -212,16 +212,6 @@ class URLMapTest(TestCase):
             u'Url map with this Hexdigest already exists.',
             self.url.save)
 
-    @override_settings(URLOGRAPHER_INDEX_ALIASES=['index.html'])
-    def test_save_index_refreshes_slash_cache(self):
-        urlmap = models.URLMap(
-            site=self.site, path='/test/index.html', status_code=204)
-        models.URLMapManager.cached_get(
-            self.site, '/test/', force_cache_invalidation=True)
-        self.mock.ReplayAll()
-        urlmap.save()
-        self.mock.VerifyAll()
-
 
 class URLMapManagerTest(TestCase):
     def setUp(self):
@@ -283,25 +273,6 @@ class URLMapManagerTest(TestCase):
             self.site, self.url.path, force_cache_invalidation=True)
         self.mock.VerifyAll()
         self.assertEqual(url, self.url)
-
-    @override_settings(URLOGRAPHER_INDEX_ALIASES=['index.html'],
-                       URLOGRAPHER_CACHE_PREFIX='urlographer')
-    def test_cached_get_index_alias_cache_hit(self):
-        index_urlmap = models.URLMap(site=self.site, path='/index.html',
-                                     status_code=204, hexdigest='index1234')
-        self.mock.StubOutWithMock(models.URLMap, 'set_hexdigest')
-        self.mock.StubOutWithMock(models.URLMap, 'cache_key')
-        self.mock.StubOutWithMock(models.cache, 'get')
-        models.URLMap.set_hexdigest()
-        models.URLMap.cache_key().AndReturn('urlographer:root1234')
-        models.cache.get('urlographer:root1234')
-        models.URLMap.set_hexdigest()
-        models.URLMap.cache_key().AndReturn('urlographer:index1234')
-        models.cache.get('urlographer:index1234').AndReturn(index_urlmap)
-        self.mock.ReplayAll()
-        urlmap = models.URLMap.objects.cached_get(self.site, '/')
-        self.mock.VerifyAll()
-        self.assertEqual(urlmap, index_urlmap)
 
 
 class RouteTest(TestCase):

--- a/urlographer/tests.py
+++ b/urlographer/tests.py
@@ -1033,12 +1033,18 @@ class URLMapAdminTest(TestCase):
 
 
 class ShouldAppendSlashTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
 
-    def should_append_slash_yes(self):
-        self.assertTrue(utils.should_append_slash('/news/index'))
-        self.assertTrue(utils.should_append_slash('/news/indhtm'))
+    def build_request(self, path):
+        return self.factory.get(path)
 
-    def should_append_slash_no(self):
-        self.assertFalse(utils.should_append_slash('/news/index/'))
-        self.assertFalse(utils.should_append_slash('/news/index.htm'))
-        self.assertFalse(utils.should_append_slash('/news/index.html'))
+    def test_should_append_slash_yes(self):
+        for path in ['/news/index', '/news/indhtm']:
+            request = self.build_request(path)
+            self.assertTrue(utils.should_append_slash(request))
+
+    def test_should_append_slash_no(self):
+        for path in ['/news/index/', '/news/index.htm', 'news/index.html']:
+            request = self.build_request(path)
+            self.assertFalse(utils.should_append_slash(request))

--- a/urlographer/utils.py
+++ b/urlographer/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from django.conf import settings
 from django.core.urlresolvers import get_mod_func
 
 try:
@@ -97,3 +98,13 @@ def force_cache_invalidation(request):
     Returns true if a request from contains the Cache-Control: no-cache header
     '''
     return 'no-cache' in request.META.get('HTTP_CACHE_CONTROL', '')
+
+
+def should_append_slash(request):
+    """
+    :return: boolean determining whether the a trailing slash `/`
+             should be appended to the request path
+    """
+    no_redirect = ('/', '.htm', '.html')
+    return settings.APPEND_SLASH and not (
+        request.path_info.endswith(no_redirect))

--- a/urlographer/views.py
+++ b/urlographer/views.py
@@ -41,6 +41,7 @@ from .utils import (
     force_cache_invalidation,
     get_redirect_url_with_query_string,
     get_view,
+    should_append_slash
 )
 
 settings.URLOGRAPHER_HANDLERS = getattr(settings, 'URLOGRAPHER_HANDLERS', {})
@@ -114,7 +115,10 @@ def route(request):
     elif url.status_code == 302:
         response = HttpResponseRedirect(unicode(url.redirect))
     elif url.status_code == 404:
-        response = HttpResponseNotFound()
+        if should_append_slash(request):
+            response = HttpResponsePermanentRedirect(request.path_info + '/')
+        else:
+            response = HttpResponseNotFound()
     else:
         response = HttpResponse(status=url.status_code)
 


### PR DESCRIPTION
This PR
--
* Removes redundant URLOGRAPHER_INDEX_ALIAS logic.
* Replaces `assert` with proper exception, adds unit test.
* Appends trailing slash `/` where applicable, if URL is not found
* Drops support for Django 1.6

Practical Tests Setup
--
Initial step:
* install the latest `urlographer` in your virtualenv by:
  1. loading your main application's environment
  2. navigate to the this urlographer PR's branch locally
  3. `python setup.py develop` -- this puts this PR's version of urlographer in your virtualenv

Test 1
--

* In main application
  * pick up a URL ending with `/`
  * pick up a URL which ends in `/index.html`, but redirects

- [ ] Assert URL ending with `/` returns HTTP200 as expected
- [x] Assert URL ending with `/index.html` returns HTTP301 and redirects as expected

Test 2
--
* In main application
  * pick up a URL that ends with a trailing slash `/` and returns HTTP200, but when it is without its trailing slash it returns HTTP 404 in production, i.e. let's use for testing purposes `/news/index`
  * pick up a URL that does NOT end with a trailing slash `/` but returns HTTP 200, e.g. `/tire-recalls`
  * pick up a URL which ends in `/index.html`, e.g. `/business/fundbox.html`

- [x] Assert entering `/news/index` (which in production returns HTTP 404) in your browser HTTP 301 redirects you to `/news/index/` 
- [x] Assert entering `/tire-recalls` (which in production returns HTTP 200) in your browser still returns HTTP 200
- [ ] Assert entering `/business/fundbox.html` returns HTTP200 as expected

That's all, thanks!