### PR TITLE
Adds signal when urlographer.views.route binds urlmap to request.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 env:
-    - TOXENV=django17
-    - TOXENV=django18
     - TOXENV=django19
     - TOXENV=coverage
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 env:
     - TOXENV=django19
+    - TOXENV=django110
+    - TOXENV=django111
     - TOXENV=coverage
 install:
     - pip install tox

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.views.generic.base import View
@@ -7,10 +7,9 @@ from urlographer.views import route
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-    (r'^test_page/$', View.as_view()),
-    (r'^.*$', route),
-)
+    url(r'^test_page/$', View.as_view()),
+    url(r'^.*$', route),
+]
 urlpatterns += staticfiles_urlpatterns()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django19
+envlist = django19, django110, django111
 
 [base]
 deps =
@@ -16,6 +16,20 @@ setenv =
 [testenv:django19]
 deps =
     django>=1.9, <1.10
+    django-nose>=1.4.2
+    django-extensions>=1.7.2
+    {[base]deps}
+
+[testenv:django110]
+deps =
+    django>=1.10, <1.11
+    django-nose>=1.4.2
+    django-extensions>=1.7.2
+    {[base]deps}
+
+[testenv:django111]
+deps =
+    django>=1.11, <2.0
     django-nose>=1.4.2
     django-extensions>=1.7.2
     {[base]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django17, django18, django19
+envlist = django19
 
 [base]
 deps =
@@ -12,20 +12,6 @@ commands = django-admin.py test
 setenv =
     DJANGO_SETTINGS_MODULE=test_app.settings
     PYTHONPATH={toxinidir}
-
-[testenv:django17]
-deps =
-    django>=1.7, <1.8
-    django-nose>=1.4.2
-    django-extensions<=1.5.9
-    {[base]deps}
-
-[testenv:django18]
-deps =
-    django>=1.8, <1.9
-    django-nose>=1.4.2
-    django-extensions<=1.5.9
-    {[base]deps}
 
 [testenv:django19]
 deps =
@@ -42,4 +28,4 @@ commands =
 deps =
     coverage
     coveralls
-    {[testenv:django17]deps}
+    {[testenv:django19]deps}

--- a/urlographer/signals.py
+++ b/urlographer/signals.py
@@ -1,0 +1,4 @@
+
+from django.dispatch import Signal
+
+urlmap_bound_to_request = Signal(providing_args=['request'])

--- a/urlographer/tests.py
+++ b/urlographer/tests.py
@@ -668,6 +668,30 @@ class RouteTest(TestCase):
         self.assertEqual(response.content, 'test value=testing 1 2 3')
         self.assertEqual(request.urlmap, urlmap)
 
+    def test_signal_called_on_urlmap_bound_to_request(self):
+        content_map = models.ContentMap(
+            view='urlographer.sample_views.sample_view')
+        content_map.options['test_val'] = 'testing 1 2 3'
+        content_map.save()
+        urlmap = models.URLMap.objects.create(
+            site=self.site, path='/test', content_map=content_map,
+            force_secure=False)
+        request = self.factory.get('/test')
+
+        # Mocks:
+        self.mock.StubOutWithMock(
+            views.urlmap_bound_to_request, 'send')
+
+        # Expected calls:
+        views.urlmap_bound_to_request.send(sender=None, request=request)
+
+        self.mock.ReplayAll()
+        response = views.route(request)
+        self.mock.VerifyAll()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, 'test value=testing 1 2 3')
+        self.assertEqual(request.urlmap, urlmap)
+
 
 class GetRedirectUrlWithQueryStringTest(TestCase):
 

--- a/urlographer/views.py
+++ b/urlographer/views.py
@@ -37,6 +37,7 @@ except:
     newrelic = False
 
 from .models import URLMap
+from .signals import urlmap_bound_to_request
 from .utils import (
     canonicalize_path,
     force_cache_invalidation,
@@ -87,6 +88,7 @@ def route(request):
                      force_secure=False)
 
     request.urlmap = url
+    urlmap_bound_to_request.send(sender=None, request=request)
 
     if url.force_secure and not request.is_secure():
         url_to = get_redirect_url_with_query_string(request, unicode(url))


### PR DESCRIPTION
## This PR
Adds a signal that is triggered right after the "resolved" `URLMap` instance is set on the `request`.

The signal receiver accepts the `request` as parameter, which just has had the `urlmap` associated set on it.

This provides a hook ideal for further processing, such as setting of "page type" being served in the current request, before the view instance itself goes into rendering phase.